### PR TITLE
Sane default tcp_flow_timeout

### DIFF
--- a/src/libnids.c
+++ b/src/libnids.c
@@ -109,7 +109,7 @@ struct nids_prm nids_params = {
     20000,			/* queue_limit */
     0,				/* tcp_workarounds */
     NULL,			/* pcap_desc */
-    0			        /* tcp_flow_timeout */
+    3600			/* tcp_flow_timeout */
 };
 
 static int nids_ip_filter(struct ip *x, int len)


### PR DESCRIPTION
Rather than turning off the new feature, use a sane default value of 1 hour, which should cover most firewalls' and OS's TCP idle timeout.
